### PR TITLE
I expect that after installing this plugin in the target Intellij ide…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.9.25"
-    id("org.jetbrains.intellij") version "1.17.4"
+    id("org.jetbrains.intellij") version "1.17.2"
 }
 
 group = "org.mortezapouladi"
@@ -9,14 +9,20 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
+    google()
+    gradlePluginPortal()
+    mavenLocal()
+    maven {
+        url = uri("https://packages.jetbrains.team/maven/p/idea/dev")
+    }
 }
 
 // Configure Gradle IntelliJ Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
-    version.set("2023.2.8")
-    type.set("IC") // Target IDE Platform
-    plugins.set(listOf("java"))
+    version.set("2024.1") // Use the appropriate IntelliJ IDEA version
+    type.set("IC") // IntelliJ IDEA Community Edition
+    plugins.set(listOf("java")) // Add additional plugins if needed
 }
 
 tasks {
@@ -27,6 +33,10 @@ tasks {
     }
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         kotlinOptions.jvmTarget = "17"
+    }
+
+    prepareSandbox {
+        dependsOn(processResources)
     }
 
     patchPluginXml {
@@ -43,4 +53,8 @@ tasks {
     publishPlugin {
         token.set(System.getenv("PUBLISH_TOKEN"))
     }
+}
+
+dependencies {
+    // Additional dependencies can be added if needed
 }

--- a/src/main/java/org/doitbetter/AnalyzeCodeQualityAction.java
+++ b/src/main/java/org/doitbetter/AnalyzeCodeQualityAction.java
@@ -10,7 +10,10 @@ import com.intellij.openapi.project.Project;
 public class AnalyzeCodeQualityAction extends AnAction {
 	@Override
 	public void actionPerformed(AnActionEvent e) {
+
 		Project project = e.getProject();
+		ProjectContextHolder.setCurrentProject(project);
+
 		Map<String, String> requirements = new HashMap<>();
 		requirements.put("Unused Private Method", "java");
 		if (project != null) {

--- a/src/main/java/org/doitbetter/CodeQualityDetector.java
+++ b/src/main/java/org/doitbetter/CodeQualityDetector.java
@@ -34,7 +34,7 @@ public class CodeQualityDetector {
 
 			PsiManager psiManager = PsiManager.getInstance(project);
 			GlobalSearchScope projectScope = GlobalSearchScope.projectScope(project);
-			ToolWindow toolWindow = getToolWindow("Analyze Code Quality", project);
+			ToolWindow toolWindow = getToolWindow("Do-It-Better", project);
 
 			for (Map.Entry<String, String> requirement : requirements.entrySet()) {
 

--- a/src/main/java/org/doitbetter/IssuePanel.java
+++ b/src/main/java/org/doitbetter/IssuePanel.java
@@ -78,6 +78,7 @@ public class IssuePanel extends JPanel {
 						descriptor.navigate(true);
 					} catch (Exception ex) {
 						ex.printStackTrace();
+						ProjectContextHolder.showErrorNotification("Error: " + ex.getMessage());
 					}
 				}
 			});

--- a/src/main/java/org/doitbetter/NotificationUtil.java
+++ b/src/main/java/org/doitbetter/NotificationUtil.java
@@ -1,0 +1,21 @@
+package org.doitbetter;
+
+import com.intellij.notification.NotificationGroupManager;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.project.Project;
+
+public class NotificationUtil {
+    public static void showErrorNotification(Project project, String content) {
+        NotificationGroupManager.getInstance()
+                .getNotificationGroup("RulesManagerNotificationGroup")
+                .createNotification(content, NotificationType.ERROR)
+                .notify(project);
+    }
+
+    public static void showWarningNotification(Project project, String content) {
+        NotificationGroupManager.getInstance()
+                .getNotificationGroup("RulesManagerNotificationGroup")
+                .createNotification(content, NotificationType.WARNING)
+                .notify(project);
+    }
+}

--- a/src/main/java/org/doitbetter/ProjectContextHolder.java
+++ b/src/main/java/org/doitbetter/ProjectContextHolder.java
@@ -1,0 +1,27 @@
+package org.doitbetter;
+
+import com.intellij.openapi.project.Project;
+
+public class ProjectContextHolder {
+    private static Project currentProject;
+
+    public static void setCurrentProject(Project project) {
+        currentProject = project;
+    }
+
+    public static Project getCurrentProject() {
+        return currentProject;
+    }
+
+    public static void showErrorNotification(String content) {
+        if (currentProject != null) {
+            NotificationUtil.showErrorNotification(currentProject, content);
+        }
+    }
+
+    public static void showWarningNotification(String content) {
+        if (currentProject != null) {
+            NotificationUtil.showWarningNotification(currentProject, content);
+        }
+    }
+}

--- a/src/main/java/org/doitbetter/Rule.java
+++ b/src/main/java/org/doitbetter/Rule.java
@@ -1,0 +1,89 @@
+package org.doitbetter;
+
+import com.google.gson.annotations.SerializedName;
+
+public class Rule {
+
+    private String name;
+    private String description;
+    private boolean active;
+    @SerializedName("works_over")
+    private WorksOver worksOver;
+    private int priority;
+    @SerializedName("priority-meaning")
+    private String priorityMeaning;
+    private String context;
+    private String url;
+
+    // Getters and setters
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public WorksOver getWorksOver() {
+        return worksOver;
+    }
+
+    public void setWorksOver(WorksOver worksOver) {
+        this.worksOver = worksOver;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+
+    public String getPriorityMeaning() {
+        return priorityMeaning;
+    }
+
+    public void setPriorityMeaning(String priorityMeaning) {
+        this.priorityMeaning = priorityMeaning;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public static class WorksOver {
+        private boolean method;
+        private boolean clazz;
+
+        // Getters and setters
+        public boolean isMethod() { return method; }
+        public void setMethod(boolean method) { this.method = method; }
+
+        public boolean isClazz() { return clazz; }
+        public void setClazz(boolean clazz) { this.clazz = clazz; }
+    }
+}

--- a/src/main/java/org/doitbetter/RuleEditDialog.java
+++ b/src/main/java/org/doitbetter/RuleEditDialog.java
@@ -1,0 +1,97 @@
+package org.doitbetter;
+
+import com.intellij.openapi.ui.DialogWrapper;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class RuleEditDialog extends DialogWrapper {
+    private JTextField nameField;
+    private JTextArea descriptionArea;
+    private JCheckBox activeCheckBox;
+    private JCheckBox methodCheckBox;
+    private JCheckBox classCheckBox;
+    private JSpinner prioritySpinner;
+    private JTextField contextField;
+    private JTextField urlField;
+
+    private Rule rule;
+
+    public RuleEditDialog(Rule existingRule) {
+        super(true);
+        setTitle(existingRule == null ? "Add New Rule" : "Edit Rule");
+        this.rule = existingRule != null ? existingRule : new Rule();
+
+        init();
+        initFields();
+    }
+
+    @Override
+    protected JComponent createCenterPanel() {
+        JPanel panel = new JPanel(new GridLayout(0, 2));
+
+        panel.add(new JLabel("Name:"));
+        nameField = new JTextField(rule.getName());
+        panel.add(nameField);
+
+        panel.add(new JLabel("Description:"));
+        descriptionArea = new JTextArea(rule.getDescription());
+        panel.add(new JScrollPane(descriptionArea));
+
+        panel.add(new JLabel("Active:"));
+        activeCheckBox = new JCheckBox("", rule.isActive());
+        panel.add(activeCheckBox);
+
+        panel.add(new JLabel("Works Over:"));
+        JPanel worksOverPanel = new JPanel();
+        methodCheckBox = new JCheckBox("Method", rule.getWorksOver().isMethod());
+        classCheckBox = new JCheckBox("Class", rule.getWorksOver().isClazz());
+        worksOverPanel.add(methodCheckBox);
+        worksOverPanel.add(classCheckBox);
+        panel.add(worksOverPanel);
+
+        panel.add(new JLabel("Priority:"));
+        prioritySpinner = new JSpinner(new SpinnerNumberModel(rule.getPriority(), 1, 10, 1));
+        panel.add(prioritySpinner);
+
+        panel.add(new JLabel("Context:"));
+        contextField = new JTextField(rule.getContext());
+        panel.add(contextField);
+
+        panel.add(new JLabel("URL:"));
+        urlField = new JTextField(rule.getUrl());
+        panel.add(urlField);
+
+        return panel;
+    }
+
+    private void initFields() {
+        if (rule != null) {
+            nameField.setText(rule.getName());
+            descriptionArea.setText(rule.getDescription());
+            activeCheckBox.setSelected(rule.isActive());
+            methodCheckBox.setSelected(rule.getWorksOver().isMethod());
+            classCheckBox.setSelected(rule.getWorksOver().isClazz());
+            prioritySpinner.setValue(rule.getPriority());
+            contextField.setText(rule.getContext());
+            urlField.setText(rule.getUrl());
+        }
+    }
+
+    public Rule getRule() {
+        rule.setName(nameField.getText());
+        rule.setDescription(descriptionArea.getText());
+        rule.setActive(activeCheckBox.isSelected());
+
+        Rule.WorksOver worksOver = new Rule.WorksOver();
+        worksOver.setMethod(methodCheckBox.isSelected());
+        worksOver.setClazz(classCheckBox.isSelected());
+        rule.setWorksOver(worksOver);
+
+        rule.setPriority((Integer) prioritySpinner.getValue());
+        rule.setContext(contextField.getText());
+        rule.setUrl(urlField.getText());
+
+        return rule;
+    }
+}

--- a/src/main/java/org/doitbetter/RuleProcessBackgroundTask.java
+++ b/src/main/java/org/doitbetter/RuleProcessBackgroundTask.java
@@ -1,0 +1,27 @@
+package org.doitbetter;
+
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+
+public abstract class RuleProcessBackgroundTask extends Task.Backgroundable {
+    public RuleProcessBackgroundTask(Project project, String title) {
+        super(project, title, true);
+    }
+
+    @Override
+    public void run(ProgressIndicator indicator) {
+        try {
+            indicator.setText("Processing rules...");
+            indicator.setFraction(0.0);
+
+            // Start processing
+            doProcess(indicator);
+
+        } catch (Exception e) {
+            ProjectContextHolder.showErrorNotification("Processing failed: " + e.getMessage());
+        }
+    }
+
+    protected abstract void doProcess(ProgressIndicator indicator) throws Exception;
+}

--- a/src/main/java/org/doitbetter/RulesConfigurable.java
+++ b/src/main/java/org/doitbetter/RulesConfigurable.java
@@ -1,0 +1,74 @@
+package org.doitbetter;
+
+
+import java.awt.BorderLayout;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.ui.TabbedPaneWrapper;
+
+public class RulesConfigurable implements Configurable, Disposable {
+    private JPanel mainPanel;
+    private TabbedPaneWrapper tabbedPane;
+    private RulesListPanel rulesListPanel;
+    private RulesImportExportPanel importExportPanel;
+
+    @Override
+    public String getDisplayName() {
+        return "Rules Manager";
+    }
+
+    /*
+    Add to dispose() if:
+        You have event listeners: Unregister any listeners added during the lifecycle.
+        You use threads or executors: Shut them down to avoid memory leaks.
+        You work with disposable IntelliJ components: Ensure their dispose() method is called.
+     */
+    @Override
+    public void dispose() {
+        // Additional cleanup, if required
+        if (rulesListPanel != null) {
+            rulesListPanel.dispose();
+        }
+        if (importExportPanel != null) {
+            importExportPanel.dispose();
+        }
+    }
+
+    @Override
+    public JComponent createComponent() {
+        mainPanel = new JPanel(new BorderLayout());
+        tabbedPane = new TabbedPaneWrapper(this); // `this` is a Disposable
+
+        // First Tab: Rules List
+        rulesListPanel = new RulesListPanel();
+        tabbedPane.addTab("Rules List", rulesListPanel);
+
+        // Second Tab: Import/Export
+        importExportPanel = new RulesImportExportPanel(rulesListPanel);
+        tabbedPane.addTab("Import/Export", importExportPanel);
+
+        mainPanel.add(tabbedPane.getComponent(), BorderLayout.CENTER);
+        return mainPanel;
+    }
+
+    @Override
+    public boolean isModified() {
+        return rulesListPanel.isModified() || importExportPanel.isModified();
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        rulesListPanel.apply();
+        importExportPanel.apply();
+    }
+
+    @Override
+    public void reset() {
+        rulesListPanel.reset();
+        importExportPanel.reset();
+    }
+}

--- a/src/main/java/org/doitbetter/RulesImportExportPanel.java
+++ b/src/main/java/org/doitbetter/RulesImportExportPanel.java
@@ -1,0 +1,124 @@
+package org.doitbetter;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.event.ActionListener;
+import java.io.File;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
+import com.intellij.openapi.fileChooser.FileChooser;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.vfs.VirtualFile;
+
+public class RulesImportExportPanel extends JPanel {
+    private JTextField importedFilePathField;
+    private RulesListPanel rulesListPanel;
+    private boolean modified = false;
+    private JButton importButton; // Declare as a class-level variable
+    private JButton exportButton; // Declare as a class-level variable
+
+    public RulesImportExportPanel(RulesListPanel rulesListPanel) {
+        this.rulesListPanel = rulesListPanel;
+        setLayout(new BorderLayout());
+
+        // Import section
+        JPanel importPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        importedFilePathField = new JTextField(30);
+        importedFilePathField.setEditable(false);
+
+        importButton = new JButton("Import JSON");
+        importButton.addActionListener(e -> importJsonFile());
+
+        importPanel.add(new JLabel("Imported File:"));
+        importPanel.add(importedFilePathField);
+        importPanel.add(importButton);
+
+        // Export section
+        exportButton = new JButton("Export JSON");
+        exportButton.addActionListener(e -> exportJsonFile());
+
+        JPanel exportPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        exportPanel.add(exportButton);
+
+        // Add panels to main panel
+        JPanel mainPanel = new JPanel();
+        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+        mainPanel.add(importPanel);
+        mainPanel.add(exportPanel);
+
+        add(mainPanel, BorderLayout.NORTH);
+    }
+
+    private void importJsonFile() {
+        FileChooserDescriptor descriptor = new FileChooserDescriptor(
+                true, false, false, false, false, false
+        )
+                .withFileFilter(file -> file.getName().endsWith(".json"));
+
+        VirtualFile selectedFile = FileChooser.chooseFile(descriptor, null, null);
+
+        if (selectedFile != null) {
+            try {
+                File file = new File(selectedFile.getPath());
+                RulesManager.getInstance().importRulesFromJson(file);
+
+                importedFilePathField.setText(file.getAbsolutePath());
+                rulesListPanel.reset(); // Refresh rules list
+                modified = true;
+            } catch (Exception e) {
+                ProjectContextHolder.showErrorNotification(
+                        "Failed to import JSON: " + e.getMessage()
+                );
+            }
+        }
+    }
+
+    private void exportJsonFile() {
+        FileChooserDescriptor descriptor = new FileChooserDescriptor(
+                false, true, false, false, false, false
+        );
+
+        VirtualFile selectedDir = FileChooser.chooseFile(descriptor, null, null);
+
+        if (selectedDir != null) {
+            try {
+                File file = new File(selectedDir.getPath(), "rules_export.json");
+                RulesManager.getInstance().exportRulesToJson(file);
+
+                ProjectContextHolder.showErrorNotification(
+                        "Rules exported successfully to: " + file.getAbsolutePath()
+                );
+            } catch (Exception e) {
+                ProjectContextHolder.showErrorNotification(
+                        "Failed to export JSON: " + e.getMessage()
+                );
+            }
+        }
+    }
+
+    public boolean isModified() {
+        return modified;
+    }
+
+    public void apply() {
+        modified = false;
+    }
+
+    public void reset() {
+        importedFilePathField.setText("");
+        modified = false;
+    }
+
+    public void dispose() {
+        for (ActionListener listener : importButton.getActionListeners()) {
+            importButton.removeActionListener(listener);
+        }
+        for (ActionListener listener : exportButton.getActionListeners()) {
+            exportButton.removeActionListener(listener);
+        }
+    }
+}

--- a/src/main/java/org/doitbetter/RulesListPanel.java
+++ b/src/main/java/org/doitbetter/RulesListPanel.java
@@ -1,0 +1,103 @@
+package org.doitbetter;
+
+
+import java.awt.BorderLayout;
+import java.awt.event.ActionListener;
+import java.util.List;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.table.DefaultTableModel;
+
+import com.intellij.ui.table.JBTable;
+
+public class RulesListPanel extends JPanel {
+    private JBTable rulesTable;
+    private DefaultTableModel tableModel;
+    private List<Rule> rules;
+    private JButton addButton; // Declare as a class-level variable
+    private JButton disableButton; // Declare as a class-level variable
+
+    public RulesListPanel() {
+        setLayout(new BorderLayout());
+
+        // Initialize table model
+        String[] columnNames = {"Name", "Description", "Active", "Priority", "Context"};
+        tableModel = new DefaultTableModel(columnNames, 0);
+        rulesTable = new JBTable(tableModel);
+
+        // Load existing rules
+        loadRules();
+
+        // Add scroll pane
+        JScrollPane scrollPane = new JScrollPane(rulesTable);
+        add(scrollPane, BorderLayout.CENTER);
+
+        // Add buttons panel
+        JPanel buttonsPanel = new JPanel();
+        addButton = new JButton("Add Rule");
+        disableButton = new JButton("Disable Rule");
+
+        addButton.addActionListener(e -> addNewRule());
+        disableButton.addActionListener(e -> disableSelectedRule());
+
+        buttonsPanel.add(addButton);
+        buttonsPanel.add(disableButton);
+        add(buttonsPanel, BorderLayout.SOUTH);
+    }
+
+    private void loadRules() {
+        rules = RulesManager.getInstance().getRules();
+        tableModel.setRowCount(0);
+        for (Rule rule : rules) {
+            tableModel.addRow(new Object[]{
+                    rule.getName(),
+                    rule.getDescription(),
+                    rule.isActive(),
+                    rule.getPriority(),
+                    rule.getContext()
+            });
+        }
+    }
+
+    private void addNewRule() {
+        RuleEditDialog dialog = new RuleEditDialog(null);
+        if (dialog.showAndGet()) {
+            Rule newRule = dialog.getRule();
+            RulesManager.getInstance().addRule(newRule);
+            loadRules();
+        }
+    }
+
+    private void disableSelectedRule() {
+        int selectedRow = rulesTable.getSelectedRow();
+        if (selectedRow >= 0) {
+            Rule selectedRule = rules.get(selectedRow);
+            selectedRule.setActive(false);
+            RulesManager.getInstance().updateRule(selectedRule);
+            loadRules();
+        }
+    }
+
+    public boolean isModified() {
+        // Implement modification check logic
+        return false;
+    }
+
+    public void apply() {
+        // Save changes
+    }
+
+    public void reset() {
+        loadRules();
+    }
+
+    public void dispose() {
+        for (ActionListener listener : addButton.getActionListeners()) {
+            addButton.removeActionListener(listener);
+        }
+        for (ActionListener listener : disableButton.getActionListeners()) {
+            disableButton.removeActionListener(listener);
+        }
+    }
+}

--- a/src/main/java/org/doitbetter/RulesManager.java
+++ b/src/main/java/org/doitbetter/RulesManager.java
@@ -1,0 +1,82 @@
+package org.doitbetter;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+
+@State(
+        name = "RulesManagerSettings",
+        storages = @Storage("rulesmanager.xml")
+)
+public class RulesManager implements PersistentStateComponent<RulesManager.State> {
+    private State myState = new State();
+
+    public static RulesManager getInstance() {
+        return ApplicationManager.getApplication().getService(RulesManager.class);
+    }
+
+    public List<Rule> getRules() {
+        return myState.rules;
+    }
+
+    public void addRule(Rule rule) {
+        myState.rules.add(rule);
+    }
+
+    public void updateRule(Rule rule) {
+        // Find and update existing rule
+        for (int i = 0; i < myState.rules.size(); i++) {
+            if (myState.rules.get(i).getName().equals(rule.getName())) {
+                myState.rules.set(i, rule);
+                break;
+            }
+        }
+    }
+
+    public void importRulesFromJson(File jsonFile) {
+        try (Reader reader = new FileReader(jsonFile)) {
+            Gson gson = new GsonBuilder().create();
+            State importedState = gson.fromJson(reader, State.class);
+            myState.rules = importedState.rules;
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            ProjectContextHolder.showErrorNotification("Error: " + ex.getMessage());
+        }
+    }
+
+    public void exportRulesToJson(File jsonFile) {
+        try (Writer writer = new FileWriter(jsonFile)) {
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            gson.toJson(myState, writer);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+            ProjectContextHolder.showErrorNotification("Error: " + ex.getMessage());
+        }
+    }
+
+    @Override
+    public State getState() {
+        return myState;
+    }
+
+    @Override
+    public void loadState(State state) {
+        myState = state;
+    }
+
+    public static class State {
+        public List<Rule> rules = new ArrayList<>();
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,11 +2,18 @@
     <id>org.doitbetter</id>
     <name>Do It Better</name>
     <vendor>Mory-Poul.com</vendor>
+    <version>1.0</version>
+
+    <description>A plugin to manage rules from JSON configuration</description>
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <notificationGroup id="RulesManagerNotificationGroup" displayType="BALLOON"
+                           key="rules.manager.notification.group"/>
+        <applicationConfigurable instance="org.doitbetter.RulesConfigurable"/>
+        <applicationService serviceImplementation="org.doitbetter.RulesManager"/>
         <applicationService serviceImplementation="org.doitbetter.CodeQualityDetector"/>
     </extensions>
 

--- a/src/main/resources/rules1.json
+++ b/src/main/resources/rules1.json
@@ -1,0 +1,30 @@
+{
+  "rules": [
+    {
+      "name": "rule-name-1",
+      "description": "rule-description-1",
+      "active": true,
+      "works_over": {
+        "method": true,
+        "class": false
+      },
+      "priority": 1,
+      "priority-meaning": "normal",
+      "context": "rule context 1",
+      "url": "http://www.test1.com/rule/82645"
+    },
+    {
+      "name": "rule-name-2",
+      "description": "rule-description-2",
+      "active": true,
+      "works_over": {
+        "method": false,
+        "class": true
+      },
+      "priority": 2,
+      "priority-meaning": "medium",
+      "context": "rule context 2",
+      "url": "http://www.test1.com/rule/82385"
+    }
+  ]
+}


### PR DESCRIPTION
…a, it can have a configuration page in Intellij-idea\Setting\Tool\ section.

The configuration page contains 2 tab pages.

First tab page is for showing a list of the data, let's name them rules, exist in the JSON file which is cached by the Intellij idea (IDE). Second tab page for importing a JSON file or show the one that user imported before, like the file path. And a button to allow user to export the list of rules as JSON file.

The first tab page that shows list of rules, has a plus button to add new rule to the list and a disable button to deactivate the selected rule.

The sample JSON file content is like this:

{
  "rules": [
    {
      "name": "rule-name-1",
      "description": "rule-description-1",
      "active": true,
      "works_over": {
        "method": true,
        "class": false
      },
      "priority": 1,
      "priority-meaning": "normal",
      "context": "rule context 1",
      "url": "http://www.test1.com/rule/82645"
    },
    {
      "name": "rule-name-2",
      "description": "rule-description-2",
      "active": true,
      "works_over": {
        "method": false,
        "class": true
      },
      "priority": 2,
      "priority-meaning": "medium",
      "context": "rule context 2",
      "url": "http://www.test1.com/rule/82385"
    }
  ]
}

I expect to import the rule JSON file and see the lust of rules. I would like to double click one of the rule and in the popup window it allow me to edit the rule's data. Same, if I click the add new rule button, it allow me to add rule data in the popup window ad it add the new rule to the list of rules.